### PR TITLE
Feature/detect orgs

### DIFF
--- a/Data/anbis_clean.csv
+++ b/Data/anbis_clean.csv
@@ -1,0 +1,1 @@
+rsin,currentStatutoryName,shortBusinessName

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 <b>What does it do?</b>  
 Auto_extract is being developed to extract specific information from annual report PDF files that are written in Dutch. Currently it tries to do the following:
 
-- Read the PDF file, and perform Named Entity Recognition (NER) using Stanza to extract all persons named in the document
+- Read the PDF file, and perform Named Entity Recognition (NER) using Stanza to extract all persons and all organisations named in the document, which are then processed by the processes listed below.
 - Extract persons: using a rule-based method that searches for specific keywords, this module tries to identify:
     - Ambassadors
     - People in important positions in the organisation. The code tries to determine a main job description (e.g. director or board) and a sub-job description (e.g. chairman or treasurer). Note that these positions are identified and outputted in Dutch.  
@@ -48,22 +48,34 @@ Auto_extract is being developed to extract specific information from annual repo
     
     For each person that is identified, the code searches for keywords in the sentences in which the name appears to determine the main position, or the sentence directly before or after that. Subjobs are determine based on words appearing directly before or after the name of a person for whom a main job has been determined. For the main jobs and sub positions, various ways of writing are considered in the keywords. Also before the search for the job-identification starts, name-deduplication is performed by creating lists of names that (likely) refer to one and the same person (e.g. Jane Doe and J. Doe).
 
-- Extract related organisations (under development). 
+- Extract related organisations:
+    - After Stanza NER collects all candidates for mentioned organisations, postprocessing tasks try to determine which of these candidates are most likely true candidates. This is done by considering: how often the terms is mentioned in the document, how often the term was identified as an organisation by Stanza NER, whether the term by itself (i.e. without context) is identified as an organisation by Stanza NER, whether the term contains keywords that make it likely to be a true positive, and whether the term contains keywords that make it likely to be a false positive.
+    - For those terms that are identified as true organisations, the number of occurrences in the document of each of them (in it's entirety, enclosed by word boudaries) is determined.
+    - Finally, the identified organisations are attempted to be matched on a list of provided organisations, to collect their rsin number for further analysis. See also the optional `-af` argument description. If the `-af` argument is not provided, by default, the empty file `./Data/Anbis_clean.csv` will be used. Matching is attempted both on currentStatutoryName and shortBusinessName. Only full matches (independent of capitals) and full matches with the additional term 'Stichting' at the start of the identified organisation (again independent of capitals) are considered for matching. Fuzzy matching is not used here, because it leads to a significant amount of false positives.
+
+
 - Classify the sector in which the organisation is active. The code uses a pre-trained model to identify one of eight sectors in which the organisation is active. 
+
+- Determine to which sustainable development goals (SDG) the organisation contributes to. (under development)
 
 <br/><br/>
 <b>How to run</b>  
-To run auto_extract the script `auto_extract/run_auto_extract.py` has to be executed and provided with input data and tasks. The input data (annual report pdf files) can be supplied as a single file, an entire folder, an url (referring to an online pdf file), or a text file containing a list of urls. The input data is supplied using one of the following arguments:
+To run auto_extract the script `auto_extract/run_auto_extract.py` has to be executed and provided with input data and tasks. The following arguments can be provided when running the script:
 
-- `-f`: to supply a single pdf file as argument. The full command would for example be: `python ./auto_extract/run_auto_extract.py -f 'annual_report.pdf'`
-- `-d`: to supply a directory containing pdf files as argument. The code will process all pdf files in the folder. If the folder contains subfolders or non-pdf files, these will be ignored. E.g. `python ./auto_extract/run_auto_extract.py -d './Annual_reports'`
-- `-u`: to supply an url to a pdf file as argument. E.g. `python ./auto_extract/run_auto_extract.py -u https://www.website.com/annual_report.pdf`
-- `-uf`: to supply a text file containing a list of urls as argument. E.g. `python ./auto_extract/run_auto_extract.py -uf 'my_urls.txt'`.  
+- The input data (annual report pdf files) can be supplied as a single file, an entire folder, an url (referring to an online pdf file), or a text file containing a list of urls. The input data is supplied using one of the following arguments:
+
+    - `-f`: to supply a single pdf file as argument. The full command would for example be: `python ./auto_extract/run_auto_extract.py -f 'annual_report.pdf'`
+    - `-d`: to supply a directory containing pdf files as argument. The code will process all pdf files in the folder. If the folder contains subfolders or non-pdf files, these will be ignored. E.g. `python ./auto_extract/run_auto_extract.py -d './Annual_reports'`
+    - `-u`: to supply an url to a pdf file as argument. E.g. `python ./auto_extract/run_auto_extract.py -u https://www.website.com/annual_report.pdf`
+    - `-uf`: to supply a text file containing a list of urls as argument. E.g. `python ./auto_extract/run_auto_extract.py -uf 'my_urls.txt'`.  
 The text file should simply contain one url per line, without headers and footers. 
 
-Additionally, it is possible to define which tasks should be performed using the `-t` argument with one or more of the options: `people` (to perform the tasks described under extract persons), `orgs` (to perform tge tasks described under extract related organisations), `sector` (to classify the sector in which the organisation is active) or `all` (to perform all tasks). It is possible to supply multiple tasks. E.g.:  
+- Additionally, it is possible to define which tasks should be performed using the `-t` argument with one or more of the options: `people` (to perform the tasks described under extract persons), `orgs` (to perform tge tasks described under extract related organisations), `sector` (to classify the sector in which the organisation is active) or `all` (to perform all tasks). It is possible to supply multiple tasks. E.g.:  
 `python ./auto_extract/run_auto_extract.py -f 'annual_report.pdf' -t people sector`  
 If the `-t` argument is not provided, the code will perform all tasks by default.
+
+- Finally, the `-af` argument can be provided to pass a .csv file which will be used with the `orgs` task. The file should contain (at least) the columns rsin, currentStatutoryName, and shortBusinessName. An empty example file, that is also the default file, can be found in the folder 'Data'. The data in the file will be used to try to match identified named organisations on to collect their rsin number provided in the `-af` file. For example, use your own './comparison.csv' file by running:
+`python ./auto_extract/run_auto_extract.py -f 'annual_report.pdf' -t orgs -af ./comparison.csv` 
 
 <br/><br/>
 <b>Output</b>  

--- a/auto_extract/extract_related_orgs.py
+++ b/auto_extract/extract_related_orgs.py
@@ -121,7 +121,7 @@ def collect_orgs(infile):
                 single_orgs.append(org)
     for org in single_orgs:
         true_orgs = check_single_orgs(org, true_orgs, doc_c)
-    return list(set(true_orgs))
+    return sorted(list(set(true_orgs)))
 
 
 def decide_org(org, pco_p, pco_c, org_pp, org_c):
@@ -288,7 +288,7 @@ def match_anbis(df_in, anbis_file):
     df2_out = df2.merge(df[df['shortBusinessName'].notnull()], how='left',
                         left_on='matched_anbi', right_on='shortBusinessName')
     df_out = pd.concat([df1_out, df2_out])
-    return df_out
+    return df_out.sort_values(by=['Input_file', 'mentioned_organization'])
 
 
 def apply_matching(df, m, c2, c3):

--- a/auto_extract/extract_related_orgs.py
+++ b/auto_extract/extract_related_orgs.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Netherlands eScience Center and Vrije Universiteit Amsterdam
 # Licensed under the Apache License, version 2.0. See LICENSE for details.
 
+import re
 # Extract all named organisations in annual report
 # Count the number of times each is mentioned
 # Classify relation type:
@@ -16,32 +17,194 @@
 #   - NGO
 #   - onderwijs-/kennisinstelling
 import numpy as np
+import stanza
+from auto_extract.preprocessing import preprocess_pdf
 
 
-def count_orgs(text, org):
-    ''' Count the number of times an organization is mentioned in a text.'''
-    return text.count(org)
+nlp = stanza.Pipeline(lang='nl', processors='tokenize, ner')
+
+class Org_Keywords:
+    true_keys = ['bv', 'b.v', 'fonds', 'fondsen', 'ministerie', 'umc', 'nederland']
+    true_keys_cap = ['Association', 'Hospice', 'Hogeschool', 'Institute', 'Instituut',
+                     'Medisch Centrum', 'Stichting', 'Universiteit', 'University', 'Vereniging',
+                     'Ziekenhuis', 'Ziekenhuizen'
+                    ]
+    false_keys = ['raad', 'bestuur', 'board', 'corona', 'covid', 'directeur', 'docent', 'activa', 'passiva', 
+                 'reserve', 'www.', '.nl', '.com', 'overige', 'baten', 'saldo', 'interim',
+                 'managing', 'manager', 'afdeling', 'regeling', 'rj640', 'rj 640', 'rj 650','rj 2016', 'penningmeester',
+                 'voorzitter', 'kosten', 'bedrijfsvoering', 'congres', 'akkoord', 'overhead', 'fy2'
+                 'cao', 'begroting', 'commissie', 'committee', 'richtlijn', 'emeritus', 'abonnement', 'startdatum', 'portefeuille',
+                 'netwerk', 'lid ', 'functie', 'review']
+    false_keys_s = ['avg', 'mt', 'db', 'ab', 'managementteam', 'management team', 'management', 'marketing', 'p&o', 'rj', 'ict',
+                    'hr', 'hrm', 'crm', 'arbo', 'rvt', 'eur', 'bhv', 'fondsenwerving', 'pensioenfonds', 'pensioenfondsen',
+                    'eindredactie', 'fte', 'ceo', 'cio', 'cto', 'cfo', 'vgba', 'vio', 'industrie', 'b&a', 
+                    'beheer & administratie', 'beweging', 'huisvesting', 'ebola', 'sars', 'finance & operations', 'GDPR',
+                    'Human Resources']
 
 
-def classify_relation_type():
-    ''' Classify the relationship between a mentioned organization and the main organization'''
-    relation_type = 'none'
-    return relation_type
+def collect_orgs(infile):
+    '''Determine all entities in the text using NER. Select candidates by applying NER
+    to different preprocessing choices. Perform additional checks to determine which
+    candidates are most likely true entities.'''
+    true_orgs = []
+    false_orgs = []
+    single_orgs = []
+    doc_c = nlp(preprocess_pdf(infile, r_blankline=', ', r_par=', '))
+    org_c = np.unique([f'{ent.text}' for ent in doc_c.ents if ent.type == "ORG"], return_counts=True)
+    doc_p = nlp(preprocess_pdf(infile, r_blankline='. ', r_par=', '))
+    org_p = np.unique([ent.text.rstrip('.') for ent in doc_p.ents if ent.type == "ORG"], return_counts=True)
+    doc_pp = nlp(preprocess_pdf(infile, r_blankline='. ', r_eol='. ', r_par=', '))
+    org_pp = np.unique([ent.text.rstrip('.') for ent in doc_pp.ents if ent.type == "ORG"])
+    org_all = np.unique(np.concatenate((org_c[0], org_p[0], org_pp)))
+    for org in org_all:
+        org = org.rstrip('.')
+        print(org)
+        pco_c = percentage_considered_org(doc_c, org, org_c[0], org_c[1])
+        print('c', pco_c)
+        pco_p = percentage_considered_org(doc_p, org, org_p[0], org_p[1])
+        print('p', pco_p)
+        decision = decide_org(org, pco_p, pco_c, org_pp, org_c)
+        if org in org_pp: 
+            print('in org_pp')
+        print('decision = ', org, decision)
+        # input()
+        # process conclusion
+        if decision is True:
+            true_orgs.append(org)
+        elif decision is False or decision == 'no':
+            false_orgs.append(org)
+        elif decision == 'maybe':
+            single_orgs.append(org)
+    for org in single_orgs:
+        true_orgs, false_orgs = check_single_orgs(org, true_orgs, false_orgs, doc_c)
+    print(sorted(true_orgs))
+    print(sorted(false_orgs))
+    return true_orgs
 
 
-def classify_org_type():
-    ''' Classify what kind of organization '''
-    org_type = 'none'
-    return org_type
+def decide_org(org, pco_p, pco_c, org_pp, org_c):
+    final = False
+    is_org = single_org_check(org)
+    per_p, n_p = pco_p
+    per_c, n_c = pco_c
+    # decision tree
+    print('is org', is_org)
+    print('n_p', n_p, 'n_c', n_c)
+    if n_p >= 5 or n_c >= 5:
+        if per_p >= 50. and per_c >= 50.:
+            final = True
+    elif n_p >= 3 or n_c >= 3:
+        if per_p >= 66. and per_c >= 66.:
+            final = True
+    elif n_p == 2:
+        final = 'no'
+        if per_p == 100.:
+            final = True
+    elif n_p == 1 and n_c == 1:
+        kw_check = keyword_check(final, org)
+        if per_p == per_c == 100. and ((org in org_pp) or (is_org is True) or (kw_check is True)):
+            final = 'maybe'
+        elif per_p == 100. and (org in o for o in org_c) and ((org in org_pp) or (is_org is True) or (kw_check is True)):
+            final = 'maybe'
+        elif (org in org_pp) and (kw_check is True):
+            final = 'maybe'
+        else:
+            final = 'no'
+    elif (is_org and org in org_pp):
+        if per_p == -10 or per_c == -10:
+            final = 'no'
+        else:
+            final = 'maybe'
+    # check for hits and misses
+    print('pre final', final)
+    if final not in ('maybe', 'no') and n_p>=1:
+        final = keyword_check(final, org)
+    print('final', final)
+    return final
 
 
-def extract_orgs(text, orgs):
-    ''' Extract the details of all organizations mentioned in text'''
-    orgs_details = np.empty(len(orgs), dtype='U200')
-    for i, org in enumerate(orgs):
-        org_count = count_orgs(text, org)
-        rel_type = classify_relation_type()
-        org_type = classify_org_type()
-        orgs_details[i] = (str(org) + ' - ' + str(org_count) + ' - ' + str(rel_type) + ' - ' +
-                           str(org_type))
-    return orgs_details
+def keyword_check(final, org):
+    ''' Check if org is likely to be or not be an organisation based on keywords.'''
+    for kw in Org_Keywords.true_keys:
+        if kw in org.lower():
+            final = True
+            if len(org)==len(kw):
+                final = False
+    for kw in Org_Keywords.true_keys_cap:
+        if len(re.findall((r"\b" + kw + r"\b"), org)) > 0:
+            final = True
+            if len(org)==len(kw):
+                final = False
+    if final is True:
+        for kw in Org_Keywords.false_keys:
+            if kw in org.lower():
+                final = False
+        if org.lower() in Org_Keywords.false_keys_s: 
+            final = False
+    return final
+
+
+def check_single_orgs(org, true_orgs, false_orgs, doc_c):
+    '''append org to true or false list depending on whether part_of_other 
+    is false or true respectively, and it is not blocked by teh keyword check.'''
+    final = True
+    keyword = keyword_check(final, org)
+    poo = part_of_other(true_orgs, org, doc_c)
+    if poo is False and keyword is True:
+        true_orgs.append(org)
+    else:
+        false_orgs.append(org)
+    return true_orgs, false_orgs
+
+
+def part_of_other(orgs, org, doc):
+    '''Check if a part of org is in orgs, and if that member of orgs is common.
+    Only allow for a match if the member of orgs is long enough'''
+    is_part = False
+    for o in orgs:
+        if org != o and o in org and len(o) > 5:
+            n_orgs = len(re.findall(r"\b" + o + r"\b", doc.text))
+            if n_orgs > 5:
+                kw_final = False
+                kw_o = keyword_check(kw_final, o)
+                kw_org = keyword_check(kw_final, org)
+                if kw_o is False and kw_org is True:
+                    print('true,', org, 'can be found in', o, ', n=', n_orgs, ', but has additional keyword')
+                else:
+                    print('true,', org, 'can be found in', o, ', n=', n_orgs)
+                    is_part = True
+    return is_part
+
+
+def single_org_check(org):
+    doc_o = nlp(org)
+    o_t = [f'{ent.text}' for ent in doc_o.ents if ent.type == "ORG"]
+    is_org = bool(len(o_t) == 1 and org in o_t)
+    return is_org
+
+
+def percentage_considered_org(doc, org, orgs, counts):
+    '''identify all sentences in which the org is found. Then calculate in what fraction of the total number of mentions, 
+    the org is identified as org by NER'''
+    # sentences = np.array([])
+    # for sentence in doc.sentences:
+    #    if re.search(r"\b" + org + r"\b", sentence.text):
+    #        sentences = np.append(sentences, sentence.text)
+    # text_select = np.array2string(sentences)
+    # print(org)
+    # print(text_select)
+    if '-' not in org:
+        n_orgs = len(re.findall(r"\b" + org + r"\b", doc.text.replace('-', '')))
+    else:
+        n_orgs = len(re.findall(r"\b" + org + r"\b", doc.text))
+    # print('n_orgs', n_orgs)
+    if n_orgs >= 1 and org in orgs:
+        n_orgs_found = counts[orgs == org][0]
+        # print('n_orgs found', n_orgs_found)
+        percentage = n_orgs_found/float(n_orgs)*100.
+    elif org in orgs:
+        percentage = -10
+    else:
+        percentage = 0.
+        # print('n_orgs found', 0)
+    return percentage, n_orgs

--- a/auto_extract/extract_related_orgs.py
+++ b/auto_extract/extract_related_orgs.py
@@ -275,21 +275,19 @@ def count_number_of_mentions(doc, org):
 
 def match_anbis(df_in, anbis_file):
     df = pd.read_csv(anbis_file, usecols=["rsin", "currentStatutoryName", "shortBusinessName"])
-    df_out = df_in
-    df_out['matched_anbi'] = df_out['mentioned_organization'].apply(lambda x: apply_matching(df,
-                                                                    x, 'currentStatutoryName',
-                                                                    'shortBusinessName'))
-    df2 = df_out
-    print('df_out', df_out)
-    print('df2', df2)
-    df_out = df_out.merge(df[df['currentStatutoryName'].notnull()], how='left',
-                          left_on='matched_anbi', right_on='currentStatutoryName')
-    df2 = df2.merge(df[df['shortBusinessName'].notnull()], how='left',
-                    left_on='matched_anbi', right_on='shortBusinessName')
-    print('df_out', df_out)
-    print('df2', df2)
-    df_out.loc[df_out['rsin'].isna()] = df2
-    print('df_out', df_out)
+    df_match = df_in
+    df_match['matched_anbi'] = df_match['mentioned_organization'].apply(lambda x: apply_matching(
+                                                                        df,
+                                                                        x, 'currentStatutoryName',
+                                                                        'shortBusinessName'))
+    df1 = df_match.merge(df[df['currentStatutoryName'].notnull()], how='left',
+                         left_on='matched_anbi', right_on='currentStatutoryName')
+    df2 = df1[df1['rsin'].isna()][['Input_file', 'mentioned_organization', 'n_mentions',
+                                   'matched_anbi']]
+    df1_out = df1[df1['rsin'].notnull()]
+    df2_out = df2.merge(df[df['shortBusinessName'].notnull()], how='left',
+                        left_on='matched_anbi', right_on='shortBusinessName')
+    df_out = pd.concat([df1_out, df2_out])
     return df_out
 
 

--- a/auto_extract/preprocessing.py
+++ b/auto_extract/preprocessing.py
@@ -6,11 +6,11 @@ import urllib.request
 import pdftotext
 
 
-def preprocess_pdf(infile, r_blankline=', '):
+def preprocess_pdf(infile, r_blankline=', ', r_eol=' '):
     with open(infile, 'rb') as f:
         pdf = pdftotext.PDF(f)
     text = "\n".join(pdf)
-    text = text.replace('\n\n', r_blankline).replace('\r\n\r\n', r_blankline).replace('\n', ' ')
+    text = text.replace('\n\n', r_blankline).replace('\r\n\r\n', r_blankline).replace('\n', r_eol)
     text = text.replace('\r', ' ').replace('\t', ' ')
     text = text.replace('(', '').replace(')', '').replace(';', ',')
     text = text.replace('\x0c', ' ').replace('\x07', ' ').replace('\xad', ' ')

--- a/auto_extract/preprocessing.py
+++ b/auto_extract/preprocessing.py
@@ -6,13 +6,13 @@ import urllib.request
 import pdftotext
 
 
-def preprocess_pdf(infile, r_blankline=', ', r_eol=' '):
+def preprocess_pdf(infile, r_blankline=', ', r_eol=' ', r_par=''):
     with open(infile, 'rb') as f:
         pdf = pdftotext.PDF(f)
     text = "\n".join(pdf)
     text = text.replace('\n\n', r_blankline).replace('\r\n\r\n', r_blankline).replace('\n', r_eol)
     text = text.replace('\r', ' ').replace('\t', ' ')
-    text = text.replace('(', '').replace(')', '').replace(';', ',')
+    text = text.replace('(', r_par).replace(')', r_par).replace(';', ',')
     text = text.replace('\x0c', ' ').replace('\x07', ' ').replace('\xad', ' ')
     text = text.replace('•', ', ').replace('', ', ').replace('◼', ', ').replace('\uf0b7', ' ')
     text = text.replace('/', ' / ')

--- a/auto_extract/run_auto_extract.py
+++ b/auto_extract/run_auto_extract.py
@@ -7,6 +7,7 @@ import time
 from argparse import RawTextHelpFormatter
 from datetime import datetime
 import pandas as pd
+from auto_extract.extract_related_orgs import match_anbis
 from auto_extract.preprocessing import delete_downloaded_pdf
 from auto_extract.preprocessing import download_pdf
 from auto_extract.read_pdf import extract_pdf
@@ -44,6 +45,9 @@ def main(testarg=None):
     parser.add_argument('-uf', '--url_file', help='File containing url paths to be processed.')
     parser.add_argument('-t', '--tasks', choices=['all', 'people', 'orgs', 'sectors'],
                         nargs='*', default='all', help='tasks to be performed. Default=all')
+    parser.add_argument('-af', '--anbis_file',
+                        default=os.path.join(os.path.join(os.getcwd(), 'Data'), 'anbis_clean.csv'),
+                        help='CSV file to be used for org matching,conly used for task org')
 
     if testarg:
         args = parser.parse_args(testarg)
@@ -90,7 +94,7 @@ def main(testarg=None):
             opd_p, opd_g, opd_o = extract_pdf(infile, opd_p, opd_g, opd_o, args.tasks)
             delete_downloaded_pdf()
 
-    write_output(args.tasks, opd_p, opd_g, opd_o)
+    write_output(args.tasks, opd_p, opd_g, opd_o, args.anbis_file)
 
     # end time
     print('The start time was: ', start_time)
@@ -98,13 +102,15 @@ def main(testarg=None):
     return(args)
 
 
-def write_output(tasks, opd_p, opd_g, opd_o):
+def write_output(tasks, opd_p, opd_g, opd_o, anbis_file):
     '''Return extracted information to output'''
-    outdir_path = os.path.join(os.getcwd(), 'Output')
     outtime = time.strftime("%Y%m%d_%H%M%S", time.localtime())
-    opf_p = os.path.join(outdir_path, 'output' + str(outtime) + '_people.xlsx')
-    opf_g = os.path.join(outdir_path, 'output' + str(outtime) + '_general.xlsx')
-    opf_o = os.path.join(outdir_path, 'output' + str(outtime) + '_related_organizations.xlsx')
+    opf_p = os.path.join(os.path.join(os.getcwd(), 'Output'),
+                         'output' + str(outtime) + '_people.xlsx')
+    opf_g = os.path.join(os.path.join(os.getcwd(), 'Output'),
+                         'output' + str(outtime) + '_general.xlsx')
+    opf_o = os.path.join(os.path.join(os.getcwd(), 'Output'),
+                         'output' + str(outtime) + '_related_organizations.xlsx')
     if 'all' in tasks or 'people' in tasks:
         cols_p = ['Input_file', 'Organization', 'Persons', 'Ambassadors',
                   'Board_members', 'Job_description']
@@ -125,8 +131,9 @@ def write_output(tasks, opd_p, opd_g, opd_o):
         print('Output sectors written to:', opf_g)
 
     if 'all' in tasks or 'orgs' in tasks:
-        cols_o = ['Input_file', 'Organization', 'Related_organizations']
+        cols_o = ['Input_file', 'mentioned_organization', 'n_mentions']
         df3 = pd.DataFrame(opd_o, columns=cols_o)
+        df3 = match_anbis(df3, anbis_file)
         df3.to_excel(opf_o)
         print('Output organisations written to:', opf_o)
 

--- a/auto_extract/run_auto_extract.py
+++ b/auto_extract/run_auto_extract.py
@@ -6,6 +6,7 @@ import os
 import time
 from argparse import RawTextHelpFormatter
 from datetime import datetime
+import numpy as np
 import pandas as pd
 from auto_extract.extract_related_orgs import match_anbis
 from auto_extract.preprocessing import delete_downloaded_pdf
@@ -60,9 +61,9 @@ def main(testarg=None):
     # Create the output directory if it does not exist already
     if not os.path.exists(os.path.join(os.getcwd(), 'Output')):
         os.makedirs(os.path.join(os.getcwd(), 'Output'))
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
 
     # convert tasks to list
     args.tasks = [args.tasks] if isinstance(args.tasks, str) else args.tasks

--- a/tests/test_extract_related_orgs.py
+++ b/tests/test_extract_related_orgs.py
@@ -1,10 +1,13 @@
-'''import os
+import os
 import numpy as np
 import stanza
-from auto_extract.extract_related_orgs import classify_org_type
-from auto_extract.extract_related_orgs import classify_relation_type
-from auto_extract.extract_related_orgs import count_orgs
-from auto_extract.extract_related_orgs import extract_orgs
+from auto_extract.extract_related_orgs import check_single_orgs
+from auto_extract.extract_related_orgs import collect_orgs
+from auto_extract.extract_related_orgs import decide_org
+from auto_extract.extract_related_orgs import keyword_check
+from auto_extract.extract_related_orgs import part_of_other
+from auto_extract.extract_related_orgs import percentage_considered_org
+from auto_extract.extract_related_orgs import single_org_check
 from auto_extract.preprocessing import preprocess_pdf
 
 
@@ -12,28 +15,103 @@ stanza.download('nl')
 indir = os.path.join(os.getcwd(), 'tests')
 infile = os.path.join(indir, 'test_report.pdf')
 text = preprocess_pdf(infile, ' ')
-doc = stanza.Pipeline(lang='nl', processors='tokenize,ner')(text)
-organizations = np.unique([f'{ent.text}' for ent in doc.ents if ent.type == "ORG"])
+nlp = stanza.Pipeline(lang='nl', processors='tokenize,ner')
+doc = nlp(text)
 
 
-def test_count_orgs():
-    text = ('De naam Bedrijf komt 4 keer voor in deze tekst. Bedrijf heeft een Bedrijfsnaam en is
-            een bedrijf.' +
-            'Er werken mensen bij Bedrijf, Bedrijf.')
+def test_collect_orgs():
+    orgs = collect_orgs(infile, nlp)
+    assert(orgs == ['Bedrijf2', 'Bedrijf3'])
+
+
+def test_decide_org():
     org = 'Bedrijf'
-    assert(count_orgs(text, org) == 4)
+    pco = ((50, 6), (50, 6))
+    org_pp = np.array(['Bedrijf'])
+    org_c = np.array(['Bedrijf'])
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final)
+    pco = ((50, 3), (50, 3))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final is False)
+    pco = ((70, 3), (70, 3))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(True)
+    pco = ((100, 1), (100, 1))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final == 'maybe')
+    pco = ((0, 1), (100, 1))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final == 'maybe')
+    pco = ((100, 1), (0, 1))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final == 'no')
+    pco = ((0, 0), (0, 0))
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final is False)
+    pco = ((0, 1), (0, 1))
+    org = 'Stichting Huppeldepup'
+    org_pp = ['Stichting Huppeldepup']
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final == 'maybe')
+    pco = ((0, 0), (0, 0))
+    org = 'Stichting Huppeldepup'
+    org_pp = ['Stichting Huppeldepup']
+    final = decide_org(org, pco, org_pp, org_c, nlp)
+    assert(final == 'maybe')
 
 
-def test_classify_relation_type():
-    assert(classify_relation_type() == 'none')
+def test_keyword_check():
+    org = 'Huppeldepup B.V'
+    final = False
+    kwc = keyword_check(final, org)
+    assert(kwc)
+    org = 'Ministerie'
+    final = False
+    kwc = keyword_check(final, org)
+    assert(kwc is False)
+    org = 'Hogeschool'
+    final = False
+    kwc = keyword_check(final, org)
+    assert(kwc is False)
 
 
-def test_classify_org_type():
-    assert(classify_org_type() == 'none')
+def test_check_single_orgs():
+    org = 'Stichting Huppeldepup'
+    true_orgs = []
+    doc_c = 'Hij werkt bij Stichting Huppeldepup'
+    to = check_single_orgs(org, true_orgs, doc_c)
+    e_to = ['Stichting Huppeldepup']
+    assert(to == e_to)
 
 
-def test_extract_orgs():
-    expected = np.array(['Bedrijf - 11 - none - none', 'Bedrijf2 - 1 - none - none'])
-    result = extract_orgs(text, ['Bedrijf', 'Bedrijf2'])
-    assert(isinstance(result, np.ndarray))
-    assert(np.array_equal(expected, result))'''
+def test_part_of_other():
+    orgs = ['Bedrijf']
+    org = 'Bedrijf bla'
+    is_part = part_of_other(orgs, org, doc)
+    assert(is_part)
+
+
+def test_single_org_check():
+    org = 'Stichting Huppeldepup'
+    is_org = single_org_check(org, nlp)
+    assert(is_org)
+
+
+def test_pco():
+    org = 'Bedrijf'
+    orgs = np.array(['Bedrijf'])
+    counts = np.array([7])
+    pco = percentage_considered_org(doc, org, orgs, counts)
+    assert(pco[0] == 100.)
+    assert(pco[1] == 7)
+    orgs = np.array(['Bedrij'])
+    pco = percentage_considered_org(doc, org, orgs, counts)
+    assert(pco[0] == 0.)
+    assert(pco[1] == 7)
+    counts = np.array([0])
+    org = 'Bedrijfsk'
+    orgs = np.array(['Bedrijfsk'])
+    pco = percentage_considered_org(doc, org, orgs, counts)
+    assert(pco[0] == -10.)
+    assert(pco[1] == 0)

--- a/tests/test_extract_related_orgs.py
+++ b/tests/test_extract_related_orgs.py
@@ -1,4 +1,4 @@
-import os
+'''import os
 import numpy as np
 import stanza
 from auto_extract.extract_related_orgs import classify_org_type
@@ -17,7 +17,8 @@ organizations = np.unique([f'{ent.text}' for ent in doc.ents if ent.type == "ORG
 
 
 def test_count_orgs():
-    text = ('De naam Bedrijf komt 4 keer voor in deze tekst. Bedrijf is een bedrijf.' +
+    text = ('De naam Bedrijf komt 4 keer voor in deze tekst. Bedrijf heeft een Bedrijfsnaam en is
+            een bedrijf.' +
             'Er werken mensen bij Bedrijf, Bedrijf.')
     org = 'Bedrijf'
     assert(count_orgs(text, org) == 4)
@@ -35,4 +36,4 @@ def test_extract_orgs():
     expected = np.array(['Bedrijf - 11 - none - none', 'Bedrijf2 - 1 - none - none'])
     result = extract_orgs(text, ['Bedrijf', 'Bedrijf2'])
     assert(isinstance(result, np.ndarray))
-    assert(np.array_equal(expected, result))
+    assert(np.array_equal(expected, result))'''

--- a/tests/test_read_pdf.py
+++ b/tests/test_read_pdf.py
@@ -69,11 +69,11 @@ def test_extract_pdf():
     indir = os.path.join(os.getcwd(), 'tests')
     infile = os.path.join(indir, 'test_report.pdf')
     tasks = ['all']
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
     op, og, oo = extract_pdf(infile, opd_p, opd_g, opd_o, tasks)
-    e_op = ([[os.path.basename(infile), 'Bedrijf',
+    e_op = np.array([[os.path.basename(infile), 'Bedrijf',
               'A.B. de Wit\nAnna de Wit\nBernard Zwartjes\nCornelis Geel\nD.A. Rooden\n' +
               'Dirkje Rooden\nE. van Grijs\nEduard van Grijs\nF. de Blauw\nFerdinand de Blauw\n' +
               'G. Roze\nGerard Roze\nH. Doe\nHendrik Doe\nHendrik Groen\nIsaak Paars\nJ. Doe\n' +
@@ -102,60 +102,43 @@ def test_extract_pdf():
               '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
               'Gerard Roze', 'Hendrik Groen', '', '', '',
               'Mohammed El Idrissi', 'Saïda Benali', '', '', '']])
-    e_og = [[os.path.basename(infile), 'Bedrijf', 'Natuur en milieu']]
-    e_oo = [[os.path.basename(infile), 'Bedrijf2', '1'],
-            [os.path.basename(infile), 'Bedrijf3', '1']]
-    assert(e_op == op)
-    assert(e_og == og)
-    assert(e_oo == oo)
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    e_og = np.array([[os.path.basename(infile), 'Bedrijf', 'Natuur en milieu']])
+    e_oo = np.array([[os.path.basename(infile), 'Bedrijf2', '1'],
+            [os.path.basename(infile), 'Bedrijf3', '1']])
+    assert(np.alltrue(e_op == op))
+    assert(np.alltrue(e_og == og))
+    assert(np.alltrue(e_oo == oo))
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
     tasks = ['sectors']
     op, og, oo = extract_pdf(infile, opd_p, opd_g, opd_o, tasks)
-    assert(op == [[os.path.basename(infile), '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '']])
-    assert(og == ([[os.path.basename(infile), '', 'Natuur en milieu']]))
-    assert(oo == [])
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    assert(np.alltrue(op == opd_p))
+    assert(np.alltrue(og == np.array([[os.path.basename(infile), '', 'Natuur en milieu']])))
+    assert(np.alltrue(oo == opd_o))
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
     tasks = ['people']
     op, og, oo = extract_pdf(infile, opd_p, opd_g, opd_o, tasks)
-    assert(e_op == op)
-    assert(og == ([[os.path.basename(infile), 'Bedrijf',
-                    []]]))
-    assert(oo == [])
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    assert(np.alltrue(e_op == op))
+    assert(np.alltrue(og == opd_g))
+    assert(np.alltrue(oo == opd_o))
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
     tasks = ['orgs']
     op, og, oo = extract_pdf(infile, opd_p, opd_g, opd_o, tasks)
-    assert(op == [[os.path.basename(infile), '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '',
-                   '', '', '', '', '', '', '', '', '', '']])
-    assert(og == ([[os.path.basename(infile), 'Bedrijf', []]]))
-    assert(oo == e_oo)
+    assert(np.alltrue(op == opd_p))
+    assert(np.alltrue(og == opd_g))
+    assert(np.alltrue(oo == e_oo))
     infile = os.path.join(indir, 'test_report3.pdf')
-    opd_p = []
-    opd_g = []
-    opd_o = []
+    opd_p = np.array([]).reshape(0,91)
+    opd_g = np.array([]).reshape(0,3)
+    opd_o = np.array([]).reshape(0,3)
     tasks = ['people']
     op, og, oo = extract_pdf(infile, opd_p, opd_g, opd_o, tasks)
-    e_op = ([[os.path.basename(infile), 'Bedrijf',
+    e_op = np.array(([[os.path.basename(infile), 'Bedrijf',
               'A.B. de Wit\nAnna de Wit\nBernard Zwartjes\nCornelis Geel\nH. Doe\nHendrik Doe\n' +
               'J. Doe\nJane Doe\nQuirine de Bruin\nRudolph de Bruin\nSimon de Zwart\n' +
               'Tinus de Zwart\nVictor Wit\nWillem Wit\nXantippe de Bruin\nYolanda\nZander\n',
@@ -169,5 +152,5 @@ def test_extract_pdf():
               '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
               '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
               '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
-              '', '', '', '', '', '', '', '', '', '', '', '', '']])
-    assert(op == e_op)
+              '', '', '', '', '', '', '', '', '', '', '', '', '']]))
+    assert(np.alltrue(op == e_op))

--- a/tests/test_read_pdf.py
+++ b/tests/test_read_pdf.py
@@ -103,10 +103,8 @@ def test_extract_pdf():
               'Gerard Roze', 'Hendrik Groen', '', '', '',
               'Mohammed El Idrissi', 'Saïda Benali', '', '', '']])
     e_og = [[os.path.basename(infile), 'Bedrijf', 'Natuur en milieu']]
-    e_oo = ([[infile, 'Bedrijf',
-               'Bedrijf - 11 - none - none\nBedrijf2 - 1 - none - none\n' +
-               'Bedrijf3 - 1 - none - none\nFinanciën - 1 - none - none\n' +
-               'Raad van Toezicht RvT - 1 - none - none\nRvT - 2 - none - none\n']])
+    e_oo = [[os.path.basename(infile), 'Bedrijf2', '1'],
+            [os.path.basename(infile), 'Bedrijf3', '1']]
     assert(e_op == op)
     assert(e_og == og)
     assert(e_oo == oo)
@@ -125,7 +123,7 @@ def test_extract_pdf():
                    '', '', '', '', '', '', '', '', '', '',
                    '', '', '', '', '', '', '', '', '', '']])
     assert(og == ([[os.path.basename(infile), '', 'Natuur en milieu']]))
-    assert(oo == [[infile, '', '']])
+    assert(oo == [])
     opd_p = []
     opd_g = []
     opd_o = []
@@ -134,7 +132,7 @@ def test_extract_pdf():
     assert(e_op == op)
     assert(og == ([[os.path.basename(infile), 'Bedrijf',
                     []]]))
-    assert(oo == [[infile, 'Bedrijf', '']])
+    assert(oo == [])
     opd_p = []
     opd_g = []
     opd_o = []


### PR DESCRIPTION
Merge feature detect orgs into main. 
The detect orgs feature selects all mentioned orgs in a document using stanza NER. Because for Dutch NER applied to pdf documents, many false positives are found, a postprocessing step is applied to determine which candidates are likely to be true positives. This is done based on the number of mentions in the full text, the fraction of mentions that are identified as orgs, whether the org candidates by itself (without context) is identified as org, whether it contains keywords that likely make it a true positive, or keywords that indicate a likely false positive. Additionally, for candidate orgs that are found only once in a text, it is checked wether part of it is found in a common true positive org in the text.

For those that are identified as true positives, the number of mentions in the text Is counted.

Finally, the identified orgs are matched on a supplied csv file to try to obtain their rsin number.

Additionally, output per file is now saved in numpy arrays instead of lists